### PR TITLE
#79 Handling app crash in MacDonald app

### DIFF
--- a/WoosmapGeofencing/Sources/WoosmapGeofencing/Business Logic/Region.swift
+++ b/WoosmapGeofencing/Sources/WoosmapGeofencing/Business Logic/Region.swift
@@ -98,7 +98,8 @@ public class Regions {
         do {
             let realm = try Realm()
             var identifier = id
-            if(id.contains(LocationService.RegionType.poi.rawValue) || id.contains(LocationService.RegionType.custom.rawValue)) {
+            if((id.contains(LocationService.RegionType.poi.rawValue) || id.contains(LocationService.RegionType.custom.rawValue))
+               && id.contains("<id>")){
                 identifier = id.components(separatedBy: "<id>")[1]
             } 
             let predicate = NSPredicate(format: "identifier == %@", identifier)


### PR DESCRIPTION

<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->
# Description
Checking string contain "<id>"
## Issue
closes #79 

## What
As a McDonald's user, when I open the McDo app, then the app crashs due to the Woosmap Geofencing SDK

## How
As indicated in crash log app breaks at function `getRegionFromId`, By closely look for implementation notice that string split using "<id>" and taking second part of string. This is causing app brake in case of string not contain "<id>"
Some of McDonald user has bad data on device causes this problem. We need to ask these user to reinstall app again to solve this problem.

Programatically handle in SDK code to avoid such situation like
```
if((id.contains(LocationService.RegionType.poi.rawValue) || id.contains(LocationService.RegionType.custom.rawValue))
               && id.contains("<id>")){
                identifier = id.components(separatedBy: "<id>")[1]
            } 
``` 

## Related PRs
None


# Testing
## Automated tests
- [x] Unit Tests cover the change
- [x] Smoke Tests cover the change  

## Steps to test or reproduce
To reproduce bug need to manually check with following code snippet

```
func getRegionFromId(id: String) -> Region? {
        do {
            var identifier = id
            if((id.contains(LocationService.RegionType.poi.rawValue) || id.contains(LocationService.RegionType.custom.rawValue))){
                identifier = id.components(separatedBy: "<id>")[1]
            }
            let realm = try Realm()
            let predicate = NSPredicate(format: "identifier == %@", identifier)
            let fetchedResults = realm.objects(Region.self).filter(predicate)
            if let aRegion = fetchedResults.last {
               return aRegion
            }
        } catch {
            print("Unexpected error: \(error).")
        }
        return nil
    }
```
and calling  with this parameter `getRegionFromId(id: "poi123")`

It break at line `identifier = id.components(separatedBy: "<id>")[1]`

<!-- Command to initiate automated tests.
`bender test`
-->

# Deployment
## Strategy
- [x] This is a standard deployment

<!-- Warning: if this box is not ticked, please detail the steps to deploy and TALK TO THE OPS TEAM! -->

## Migrations
<!-- Choose one -->
Yes
