### PR TITLE
Forcing ETA refresh when the user doesn't use the expected travel mode

### DIFF
--- a/WoosmapGeofencing/Sources/WoosmapGeofencing/Business Logic/RegionIsochrone.swift
+++ b/WoosmapGeofencing/Sources/WoosmapGeofencing/Business Logic/RegionIsochrone.swift
@@ -22,6 +22,7 @@ public class RegionIsochrone: Object {
     @objc public dynamic var duration = 0;
     @objc public dynamic var durationText = "";
     @objc public dynamic var type = "isochrone";
+    @objc public dynamic var expectedAverageSpeed:Double = -1;
 
     convenience init(latitude: Double, longitude: Double, radius: Int, dateCaptured: Date, identifier: String, didEnter: Bool, fromPositionDetection: Bool) {
         self.init()
@@ -32,6 +33,21 @@ public class RegionIsochrone: Object {
         self.identifier = identifier
         self.radius = radius
         self.fromPositionDetection = fromPositionDetection
+    }
+    
+   public func updateDistanceAndTime(distance:Int,
+                                     duration:Int) {
+        do {
+            let avarageSpeed:Double = Double(distance/duration)
+            let realm = try Realm()
+            try realm.write {
+                self.duration = duration
+                self.distance = distance
+                self.expectedAverageSpeed = avarageSpeed
+            }
+        } catch let error as NSError {
+            print(error)
+        }
     }
 }
 

--- a/WoosmapGeofencing/Sources/WoosmapGeofencing/Monitor.swift
+++ b/WoosmapGeofencing/Sources/WoosmapGeofencing/Monitor.swift
@@ -741,7 +741,8 @@ public class LocationService: NSObject, CLLocationManagerDelegate {
         let regionsIsochrones = RegionIsochrones.getAll()
         var regionsBeUpdated = false
         for regionIso in regionsIsochrones {
-            let distance = location.distance(from: CLLocation(latitude: regionIso.latitude, longitude: regionIso.longitude))
+            let distance = location.distance(from: CLLocation(latitude: regionIso.latitude,
+                                                              longitude: regionIso.longitude))
             if (distance < Double(distanceMaxAirDistanceFilter)) {
                 let spendtime = -regionIso.date!.timeIntervalSinceNow
                 let timeLimit = (regionIso.duration - regionIso.radius)/2
@@ -769,13 +770,38 @@ public class LocationService: NSObject, CLLocationManagerDelegate {
         
         if(regionsBeUpdated) {
             if (!optimizeDistanceRequest){
-                calculateDistanceWithRegion(origin: location.coordinate, regions: regionsIsochrones, locationId: locationId) { status, functionError in
+                calculateDistanceWithRegion(origin: location.coordinate,
+                                            regions: regionsIsochrones,
+                                            locationId: locationId) { status, functionError in
                     if(status){
                         let regionsIsochrones = RegionIsochrones.getAll()
                         regionsIsochrones.forEach { item in
+                            let didEnter = item.didEnter
                             if(item.duration != -1 ){
-                                if(item.duration <= item.radius){
-                                    //TODO: Pending part
+                                let distanceInfo = Distance()
+                                distanceInfo.distance = item.distance
+                                distanceInfo.distanceText = item.distanceText
+                                distanceInfo.duration = item.duration
+                                distanceInfo.durationText = item.durationText
+                                
+                                if(item.duration <= item.radius ){
+                                    if(didEnter == false){
+                                        let regionUpdated = RegionIsochrones.updateRegion(id: item.identifier!,
+                                                                                          didEnter: true,
+                                                                                          distanceInfo: distanceInfo)
+                                        //TODO:Missing to add in region log
+                                        self.didEventRegionIsochrone(regionIsochrone: regionUpdated)
+                                    }
+                                }
+                                else {
+                                    if(didEnter == true){
+                                        let regionUpdated = RegionIsochrones.updateRegion(id: item.identifier!,
+                                                                                          didEnter: false,
+                                                                                          distanceInfo: distanceInfo)
+                                        //TODO:Missing to add in region log
+                                        self.didEventRegionIsochrone(regionIsochrone: regionUpdated)
+                                    }
+                                    
                                 }
                             }
                         }

--- a/WoosmapGeofencing/Sources/WoosmapGeofencing/Settings.swift
+++ b/WoosmapGeofencing/Sources/WoosmapGeofencing/Settings.swift
@@ -114,3 +114,6 @@ public var SFMCAccesToken = ""
 
 public var poiRadius:Any = ""
 
+// Forcing ETA refresh when the user doesn't use the expected travel mode
+public var optimizeDistanceRequest: Bool = true
+

--- a/WoosmapGeofencing/Sources/WoosmapGeofencing/Settings.swift
+++ b/WoosmapGeofencing/Sources/WoosmapGeofencing/Settings.swift
@@ -114,6 +114,6 @@ public var SFMCAccesToken = ""
 
 public var poiRadius:Any = ""
 
-// Forcing ETA refresh when the user doesn't use the expected travel mode
+// Forcing ETA refresh when the user doesn't use the expected travel mode, Default: true
 public var optimizeDistanceRequest: Bool = true
 

--- a/WoosmapGeofencing/Sources/WoosmapGeofencing/WoosmapGeofencing.swift
+++ b/WoosmapGeofencing/Sources/WoosmapGeofencing/WoosmapGeofencing.swift
@@ -28,7 +28,7 @@ import RealmSwift
     }
     
     private func initRealm() {
-        Realm.Configuration.defaultConfiguration = Realm.Configuration(schemaVersion: 6)
+        Realm.Configuration.defaultConfiguration = Realm.Configuration(schemaVersion: 7)
     }
 
     public func getLocationService() -> LocationService {

--- a/WoosmapGeofencing/Sources/WoosmapGeofencing/WoosmapGeofencing.swift
+++ b/WoosmapGeofencing/Sources/WoosmapGeofencing/WoosmapGeofencing.swift
@@ -345,5 +345,15 @@ import RealmSwift
 
         } catch { print(error) }
     }
+    
+   
+    public var OptimizeDistanceRequest: Bool {
+        get {
+            return optimizeDistanceRequest
+        }
+        set {
+            optimizeDistanceRequest = newValue
+        }
+    }
 
 }


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

# Description
Forcing ETA refresh when the user doesn't use the expected travel mode
## Issue
closes #80


## What
Forcing ETA refresh when the user doesn't use the expected travel mode.

Isochrone geofences are based on ETA calculated by Woosmap APIs. If the user move faster than expected, the ETA has to be refreshed.

## How
Implemented  flowchart added in issue to refresh ETA with distance API

## Related PRs
N/A

# Testing
## Automated tests
- [ ] Smoke Tests cover the change  

<!-- Notice: if one of the above boxes is not ticked, please explain why. -->

## Steps to test or reproduce
<!-- Command to initiate automated tests.
`bender test`
-->

# Deployment
## Strategy
- [ ] This is a standard deployment

<!-- Warning: if this box is not ticked, please detail the steps to deploy and TALK TO THE OPS TEAM! -->

## Migrations
<!-- Choose one -->
No
